### PR TITLE
add sendevent

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -20,4 +20,5 @@ var (
 	EUnexpectedAuthHeader    = "Expected auth/request content type. Got %s"
 	EInvalidPassword         = "Could not authenticate against freeswitch with provided password: %s"
 	ECouldNotCreateMessage   = "Error while creating new message: %s"
+	ECouldNotSendEvent       = "Must send at least one event header, detected `%d` header"
 )

--- a/helpers.go
+++ b/helpers.go
@@ -6,11 +6,9 @@
 
 package goesl
 
-import "fmt"
-
 // Set - Helper that you can use to execute SET application against active ESL session
 func (sc *SocketConnection) ExecuteSet(key string, value string, sync bool) (m *Message, err error) {
-	return sc.Execute("set", fmt.Sprintf("%s=%s", key, value), sync)
+	return sc.Execute("set", key+"="+value, sync)
 }
 
 // ExecuteHangup - Helper desgned to help with executing Answer against active ESL session
@@ -29,12 +27,12 @@ func (sc *SocketConnection) ExecuteHangup(uuid string, args string, sync bool) (
 
 // BgApi - Helper designed to attach api in front of the command so that you do not need to write it
 func (sc *SocketConnection) Api(command string) error {
-	return sc.Send(fmt.Sprintf("api %s", command))
+	return sc.Send("api " + command)
 }
 
 // BgApi - Helper designed to attach bgapi in front of the command so that you do not need to write it
 func (sc *SocketConnection) BgApi(command string) error {
-	return sc.Send(fmt.Sprintf("bgapi %s", command))
+	return sc.Send("bgapi " + command)
 }
 
 // Connect - Helper designed to help you handle connection. Each outbound server when handling needs to connect e.g. accept


### PR DESCRIPTION
noticed it was impossible to send an event via this lib so I added a new function
i've tested this patch and it works well, here is example usage:
```
	var event []string
	event = append(event, "SWITCH_EVENT_MESSAGE_QUERY")
	event = append(event, fmt.Sprintf("VM-sub-call-id: %s", n.CallID))
	event = append(event, fmt.Sprintf("message-account: %s", n.Mailbox))

	err := c.SendEvent(event)
```