### PR TITLE
reuse last buffer when reading from net.Conn

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -199,9 +199,11 @@ func (c *SocketConnection) Handle() {
 
 	done := make(chan bool)
 
+	rbuf := bufio.NewReaderSize(c, ReadBufferSize)
+
 	go func() {
 		for {
-			msg, err := newMessage(bufio.NewReaderSize(c, ReadBufferSize), true)
+			msg, err := newMessage(rbuf, true)
 
 			if err != nil {
 				c.err <- err


### PR DESCRIPTION
reuse the buffer to pickup what's left in it, instead of create new buffer each time,
this should fix https://github.com/0x19/goesl/issues/1