### PR TITLE
add custom logger functionality

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -13,8 +13,8 @@ import (
 )
 
 var (
-	log = logging.MustGetLogger("goesl")
-
+	log       = logging.MustGetLogger("goesl")
+	customLog Logging
 	// Example format string. Everything except the message has a custom color
 	// which is dependent on the log level. Many fields have a custom output
 	// formatting too, eg. the time returns the hour down to the milli second.
@@ -24,27 +24,60 @@ var (
 )
 
 func Debug(message string, args ...interface{}) {
-	log.Debugf(message, args...)
+	if customLog == nil {
+		log.Debugf(message, args...)
+	} else {
+		customLog.Debugf(message, args...)
+	}
 }
 
 func Error(message string, args ...interface{}) {
-	log.Errorf(message, args...)
+	if customLog == nil {
+		log.Errorf(message, args...)
+	} else {
+		customLog.Errorf(message, args...)
+	}
 }
 
 func Notice(message string, args ...interface{}) {
-	log.Noticef(message, args...)
+	if customLog == nil {
+		log.Noticef(message, args...)
+	} else {
+		customLog.Noticef(message, args...)
+	}
 }
 
 func Info(message string, args ...interface{}) {
-	log.Infof(message, args...)
+	if customLog == nil {
+		log.Infof(message, args...)
+	} else {
+		customLog.Infof(message, args...)
+	}
 }
 
 func Warning(message string, args ...interface{}) {
-	log.Warningf(message, args...)
+	if customLog == nil {
+		log.Warningf(message, args...)
+	} else {
+		customLog.Warningf(message, args...)
+	}
+}
+
+type Logging interface {
+	Debugf(string, ...interface{})
+	Errorf(string, ...interface{})
+	Noticef(string, ...interface{})
+	Infof(string, ...interface{})
+	Warningf(string, ...interface{})
 }
 
 func init() {
 	backend := logging.NewLogBackend(os.Stderr, "", 0)
 	formatter := logging.NewBackendFormatter(backend, format)
 	logging.SetBackend(formatter)
+	customLog = nil
+}
+
+func SetCustomLogger(l Logging) {
+	customLog = l
 }


### PR DESCRIPTION
Adds the ability to specify a custom logger via interface

Useful in my projects as everything else is using the same logging library, except for goesl